### PR TITLE
Arbitrary source shape

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,16 @@ recent versions
 """""""""""""""
 
 
+*latest*: Arbitrarily shaped sources
+------------------------------------
+
+- ``fields``:
+
+  - Arbitrarily shaped sources (and therefore also loops) can now be created
+    with ``get_source_field`` providing a ``src`` that consists of x-, y-,
+    and z-coordinates of all endpoints of the individual segments.
+
+
 v0.15.3: Move to EMSiG
 ----------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,12 @@ recent versions
     with ``get_source_field`` providing a ``src`` that consists of x-, y-,
     and z-coordinates of all endpoints of the individual segments.
 
+  - Simple magnetic "dipole" sources can now be created with
+    ``get_source_field`` by providing a point dipole (``[x, y, z, azm, dip]``)
+    and set ``msrc=True`` (new fct-keyword). This will create a square loop of
+    1x1 m perpendicular to the defined point dipole, hence simulating a
+    magnetic source.
+
 
 v0.15.3: Move to EMSiG
 ----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,17 +9,21 @@ recent versions
 *latest*: Arbitrarily shaped sources
 ------------------------------------
 
-- ``fields``:
+- ``fields.get_source_field``:
 
-  - Arbitrarily shaped sources (and therefore also loops) can now be created
-    with ``get_source_field`` providing a ``src`` that consists of x-, y-,
-    and z-coordinates of all endpoints of the individual segments.
+  - Arbitrarily shaped sources (and therefore also loops) can now be created by
+    providing a ``src`` that consists of x-, y-, and z-coordinates of all
+    endpoints of the individual segments.
 
-  - Simple magnetic "dipole" sources can now be created with
-    ``get_source_field`` by providing a point dipole (``[x, y, z, azm, dip]``)
-    and set ``msrc=True`` (new fct-keyword). This will create a square loop of
-    1x1 m perpendicular to the defined point dipole, hence simulating a
-    magnetic source.
+  - Simple magnetic "dipole" sources can now be created by providing a point
+    dipole (``[x, y, z, azm, dip]``) and set ``msrc=True`` (new fct-keyword).
+    This will create a square loop of 1x1 m perpendicular to the defined point
+    dipole, hence simulating a magnetic source.
+
+  - Bugfix: Fix floating point issue when the smaller coordinate of a finite
+    length dipole source was very close to a node, but not exactly (in the
+    order of much less than nanometers. It then overestimated that source by
+    putting it in twice as many cells, but not normalizing for it.
 
 
 v0.15.3: Move to EMSiG


### PR DESCRIPTION
Improve `emg3d` to work with arbitrarily shaped sources, which includes loops (hence "magnetic" sources") and also magnetic receivers for the adjoint-state gradient (which requires magnetic sources).

=> #101, #132 

TODOs

- [x] Arbitrary source shape.
- [x] loop-shortcut for arbitrarily rotated unit loops.
- [ ] Implement mrec/msrc in adjoint-state gradient => comes in another PR later.
- [x] **Check source strength** (`strength=[0, 1, x]`) !
- [x] Fix bug in `get_source_field` depending on grid