### PR TITLE
PEC to prolongation

### DIFF
--- a/emg3d/fields.py
+++ b/emg3d/fields.py
@@ -38,10 +38,8 @@ class Field(np.ndarray):
     z-directed fields as attributes, stored as `fx`, `fy`, and `fz`. The
     default array contains the whole field, which can be the electric field,
     the source field, or the residual field, in a 1D array. A `Field` instance
-    has additionally the property `ensure_pec` which, if called, ensures
-    Perfect Electric Conductor (PEC) boundary condition. It also has the two
-    attributes `amp` and `pha` for the amplitude and phase, as common in
-    frequency-domain CSEM.
+    has additionally the two attributes `amp` and `pha` for the amplitude and
+    phase, as common in frequency-domain CSEM.
 
     A `Field` can be initiated in three ways:
 
@@ -292,27 +290,6 @@ class Field(np.ndarray):
                 self._sval = None
 
         return self._sval
-
-    @property
-    def ensure_pec(self):
-        """Set Perfect Electric Conductor (PEC) boundary condition."""
-        # Apply PEC to fx
-        self.fx[:, 0, :] = 0.
-        self.fx[:, -1, :] = 0.
-        self.fx[:, :, 0] = 0.
-        self.fx[:, :, -1] = 0.
-
-        # Apply PEC to fy
-        self.fy[0, :, :] = 0.
-        self.fy[-1, :, :] = 0.
-        self.fy[:, :, 0] = 0.
-        self.fy[:, :, -1] = 0.
-
-        # Apply PEC to fz
-        self.fz[0, :, :] = 0.
-        self.fz[-1, :, :] = 0.
-        self.fz[:, 0, :] = 0.
-        self.fz[:, -1, :] = 0.
 
     # INTERPOLATION
     def interpolate_to_grid(self, grid, **interpolate_opts):

--- a/emg3d/solver.py
+++ b/emg3d/solver.py
@@ -172,8 +172,7 @@ def solve(model, sfield, sslsolver=True, semicoarsening=True,
         carrying out one multigrid cycle helps to stabilize it.
 
         Note that the tangential field at the boundary of a provided efield is
-        set to zero ensuring the perfect electric conductor boundary condition
-        (PEC).
+        set to zero to ensure a PEC boundary (perfect electric conductor).
 
     tol : float, default: 1e-6
         Convergence tolerance.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -280,12 +280,9 @@ def test_restrict(njit):
     ffield = fields.Field(fgrid)
 
     # Put in values.
-    ffield.fx[:, :, :] = 1
-    ffield.fy[:, :, :] = 2
-    ffield.fz[:, :, :] = 4
-
-    # Ensure PEC.
-    ffield.ensure_pec
+    ffield.fx[:, 1:-1, 1:-1] = 1
+    ffield.fy[1:-1, :, 1:-1] = 2
+    ffield.fz[1:-1, 1:-1, :] = 4
 
     # Get weigths
     wlr = np.zeros(fgrid.shape_nodes[0], dtype=np.float_)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -279,15 +279,6 @@ def test_field(tmpdir):
     ee3.fz = ee.fz
     assert_allclose(ee.field, ee3.field)
 
-    # Check PEC
-    ee.ensure_pec
-    assert abs(np.sum(ee.fx[:, 0, :] + ee.fx[:, -1, :])) == 0
-    assert abs(np.sum(ee.fx[:, :, 0] + ee.fx[:, :, -1])) == 0
-    assert abs(np.sum(ee.fy[0, :, :] + ee.fy[-1, :, :])) == 0
-    assert abs(np.sum(ee.fy[:, :, 0] + ee.fy[:, :, -1])) == 0
-    assert abs(np.sum(ee.fz[0, :, :] + ee.fz[-1, :, :])) == 0
-    assert abs(np.sum(ee.fz[:, 0, :] + ee.fz[:, -1, :])) == 0
-
     # Test copy
     e2 = ee.copy()
     assert_allclose(ee.field, e2.field)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -52,7 +52,6 @@ def test_save_and_load(tmpdir, capsys):
     field = fields.Field(grid)
     ne = grid.n_edges_x + grid.n_edges_y + grid.n_edges_z
     field.field = np.arange(ne)+1j*np.ones(ne)
-    field.ensure_pec
 
     # Some model.
     property_x = create_dummy(*grid.shape_cells, False)


### PR DESCRIPTION
The only place were we really have to ensure PEC is in the prolongation (plus ensure PEC if an `efield` is provided to the solver).

This PR removes the `Field.ensure_pec` and directly puts the implementation in `solver.prolongation()`.