### PR TITLE
addition of `data_type=amp` 

### DIFF
--- a/emg3d/simulations.py
+++ b/emg3d/simulations.py
@@ -973,40 +973,12 @@ class Simulation:
             # (Only relevant in case of "relative" receivers.)
             coords = rec.coordinates_abs(self.survey.sources[source])
                 
-            if rec.xtype == 'electric':
-                # Get residual field and add it to the total field.
-                rfield.field += fields.get_source_field(
-                        grid=grid,
-                        source=src_fct(coords, strength=strength),
-                        frequency=freq,
-                ).field
-
-            elif rec.xtype == 'magnetic':
-                # Use of SimPEG for calculating rfield
-                C = grid.edgeCurl
-                rec_loc = rec.coordinates[:3]
-                azimuth = rec.coordinates[3]
-                elevation = rec.coordinates[4]
-                # Requires a generalization, but should be simple by combining x, y, z
-                # Aslo no need to store P every time, so would be wortwhile to store
-                # in a receiver object?
-                
-                if (azimuth == 0) & (elevation==0):
-                    location_type='Fx'
-                elif (azimuth == 90) & (elevation==0):
-                    location_type='Fy'
-                elif (azimuth == 0) & (elevation==90):
-                    location_type='Fz'
-                P = grid.get_interpolation_matrix(rec_loc, location_type=location_type)    
-                # h = -C*e / (i*omega*mu)       
-                # smu0 = i*omega*mu
-                h_deriv = ((C.T @ P.T).toarray().ravel() / rfield.smu0).conj()
-
-                rfield.field += fields.Field(
-                        grid=grid,
-                        data=np.conj(-h_deriv * residual * weight),
-                        frequency=freq,
-                ).field
+            # Get residual field and add it to the total field.
+            rfield.field += fields.get_source_field(
+                    grid=grid,
+                    source=src_fct(coords, strength=strength),
+                    frequency=freq,
+            ).field
 
         return rfield
 


### PR DESCRIPTION
This was for calculating d|e| /  d|sigma| or d|e| /  d|sigma|^H. 
It was not possible to handle this on simpeg side. 
Added the `data_type` (as a property) in recevers.py
Added the `data_deriv` (as a function)