### PR TITLE
Other data types than complex

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,9 @@ latest
     magnetic permeabilities in the vincinity of the source).
   - Both receivers (``Rx{Electric;Magnetic}Point``) can now produce their
     proper adjoint (thanks to @sgkang!).
+  - Receivers have a new parameter ``data_type``; by default this is
+    ``complex``, but in addition there are new the options ``amp-pha``,
+    ``amplitude``, and ``phase``.
 
 - Changes in Simulation and parallel execution.
 
@@ -28,10 +31,6 @@ latest
 
   - Models and Fields return itself (not a copy) when the grid provided to
     ``interpolate_to_grid`` is the same as the current one.
-
-- WIP: Other data types than complex data.
-
-- WIP: Proper adjoint for magnetic receivers.
 
 
 v1.2.1: Remove optimize & bug fix

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,8 +17,8 @@ latest
   - Both receivers (``Rx{Electric;Magnetic}Point``) can now produce their
     proper adjoint (thanks to @sgkang!).
   - Receivers have a new parameter ``data_type``; by default this is
-    ``complex``, but in addition there are new the options ``amp-pha``,
-    ``amplitude``, and ``phase``.
+    ``complex``, but in addition there are new the (experimental) options
+    ``amplitude`` and ``phase``.
 
 - Changes in Simulation and parallel execution.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,9 @@ latest
   - Models and Fields return itself (not a copy) when the grid provided to
     ``interpolate_to_grid`` is the same as the current one.
 
+- WIP: Other data types than complex data.
+
+- WIP: Proper adjoint for magnetic receivers.
 
 
 v1.2.1: Remove optimize & bug fix

--- a/emg3d/electrodes.py
+++ b/emg3d/electrodes.py
@@ -593,8 +593,10 @@ class Receiver(Wire):
         complex values, but the meaning of the real and imaginary part differs
         depending on the data type. Currently implemented are:
 
-        - 'complex': Complex values: Real + i.Imag
-        - 'amp-pha': Amplitude and phase: Amp + i.Pha
+        - ``'complex'``: Complex values: Real + j Imag
+        - ``'amp-pha'``: Amplitude and phase: Amplitude + j Phase
+        - ``'amplitude'``: Amplitude and phase: Amplitude + j 0
+        - ``'phase'``: Amplitude and phase: 0 + j Phase
 
     """
 
@@ -605,7 +607,8 @@ class Receiver(Wire):
         """Initiate a receiver."""
 
         # Check data type is a known type.
-        if data_type.lower() not in ['complex', 'amp-pha']:
+        known = ['complex', 'amp-pha', 'amplitude', 'phase']
+        if data_type.lower() not in known:
             raise ValueError(f"Unknown `data_type` {data_type}.")
 
         # Store relative, add a repr-addition.
@@ -627,11 +630,29 @@ class Receiver(Wire):
         """Data type of the measured responses."""
         return self._data_type
 
+    def from_complex(self, complex_data):
+        """Return data in `data_type` from complex values."""
+
+        if self.data_type == 'amp-pha':
+            return abs(complex_data) + 1j*np.angle(complex_data)
+
+        elif self.data_type == 'amplitude':
+            return abs(complex_data) + 0j
+
+        elif self.data_type == 'phase':
+            return 1j*np.angle(complex_data)
+
+        else:
+            return complex_data
+
     def derivative_chain(self, data, complex_data):
         """Chain rule for data types other than complex."""
 
-        if self.data_type == 'amp-pha':
-            data *= complex_data.conj() / abs(complex_data)
+        if self.data_type in ['amp-pha', 'amplitude']:
+            data.real *= np.real(complex_data.conj()/abs(complex_data))
+
+        if self.data_type in ['amp-pha', 'phase']:
+            data.imag *= np.real(-1j*complex_data.conj()/abs(complex_data)**2)
 
     def center_abs(self, source):
         """Returns points as absolute positions."""
@@ -670,8 +691,10 @@ class RxElectricPoint(Receiver, Point):
         complex values, but the meaning of the real and imaginary part differs
         depending on the data type. Currently implemented are:
 
-        - 'complex': Complex values: Real + i.Imag
-        - 'amp-pha': Amplitude and phase: Amp + i.Pha
+        - ``'complex'``: Complex values: Real + j Imag
+        - ``'amp-pha'``: Amplitude and phase: Amplitude + j Phase
+        - ``'amplitude'``: Amplitude and phase: Amplitude + j 0
+        - ``'phase'``: Amplitude and phase: 0 + j Phase
 
     """
     _adjoint_source = TxElectricPoint
@@ -708,8 +731,10 @@ class RxMagneticPoint(Receiver, Point):
         complex values, but the meaning of the real and imaginary part differs
         depending on the data type. Currently implemented are:
 
-        - 'complex': Complex values: Real + i.Imag
-        - 'amp-pha': Amplitude and phase: Amp + i.Pha
+        - ``'complex'``: Complex values: Real + j Imag
+        - ``'amp-pha'``: Amplitude and phase: Amplitude + j Phase
+        - ``'amplitude'``: Amplitude and phase: Amplitude + j 0
+        - ``'phase'``: Amplitude and phase: 0 + j Phase
 
     """
     _adjoint_source = TxMagneticPoint

--- a/emg3d/electrodes.py
+++ b/emg3d/electrodes.py
@@ -595,7 +595,7 @@ class Receiver(Wire):
 
         - ``'complex'``: Complex values:        Real + j Imag
         - ``'amplitude'``: Amplitude and phase:  Amp + j 0
-        - ``'phase'``: Amplitude and phase:        0 + j Pha
+        - ``'phase'``: Amplitude and phase:      Pha + j 0
 
         The preferred choice is complex, but the latter two are implemented for
         the case where phase or amplitude information is not available or very
@@ -639,7 +639,7 @@ class Receiver(Wire):
             return complex(abs(complex_data))
 
         elif self.data_type == 'phase':
-            return 1j*np.angle(complex_data)
+            return complex(np.angle(complex_data))
 
         else:
             return complex_data
@@ -647,11 +647,11 @@ class Receiver(Wire):
     def derivative_chain(self, data, complex_data):
         """Chain rule for data types other than complex."""
 
-        if self.data_type == 'amplitude':  # Amp + j 0
-            data.real *= np.real(complex_data.conj()/abs(complex_data))
+        if self.data_type == 'amplitude':  # Amp + 0j
+            data *= complex_data.conj()/abs(complex_data)
 
-        elif self.data_type == 'phase':    # 0 + j Pha
-            data.imag *= np.real(-1j*complex_data.conj()/abs(complex_data)**2)
+        elif self.data_type == 'phase':    # Pha + 0j
+            data *= -1j*complex_data.conj()/abs(complex_data)**2
 
     def center_abs(self, source):
         """Returns points as absolute positions."""

--- a/emg3d/electrodes.py
+++ b/emg3d/electrodes.py
@@ -593,10 +593,13 @@ class Receiver(Wire):
         complex values, but the meaning of the real and imaginary part differs
         depending on the data type. Currently implemented are:
 
-        - ``'complex'``: Complex values: Real + j Imag
-        - ``'amp-pha'``: Amplitude and phase: Amplitude + j Phase
-        - ``'amplitude'``: Amplitude and phase: Amplitude + j 0
-        - ``'phase'``: Amplitude and phase: 0 + j Phase
+        - ``'complex'``: Complex values:        Real + j Imag
+        - ``'amplitude'``: Amplitude and phase:  Amp + j 0
+        - ``'phase'``: Amplitude and phase:        0 + j Pha
+
+        The preferred choice is complex, but the latter two are implemented for
+        the case where phase or amplitude information is not available or very
+        poor.
 
     """
 
@@ -607,8 +610,7 @@ class Receiver(Wire):
         """Initiate a receiver."""
 
         # Check data type is a known type.
-        known = ['complex', 'amp-pha', 'amplitude', 'phase']
-        if data_type.lower() not in known:
+        if data_type.lower() not in ['complex', 'amplitude', 'phase']:
             raise ValueError(f"Unknown `data_type` {data_type}.")
 
         # Store relative, add a repr-addition.
@@ -631,13 +633,10 @@ class Receiver(Wire):
         return self._data_type
 
     def from_complex(self, complex_data):
-        """Return data in `data_type` from complex values."""
+        """Return data in `data_type`-format from complex values."""
 
-        if self.data_type == 'amp-pha':
-            return abs(complex_data) + 1j*np.angle(complex_data)
-
-        elif self.data_type == 'amplitude':
-            return abs(complex_data) + 0j
+        if self.data_type == 'amplitude':
+            return complex(abs(complex_data))
 
         elif self.data_type == 'phase':
             return 1j*np.angle(complex_data)
@@ -648,10 +647,10 @@ class Receiver(Wire):
     def derivative_chain(self, data, complex_data):
         """Chain rule for data types other than complex."""
 
-        if self.data_type in ['amp-pha', 'amplitude']:
+        if self.data_type == 'amplitude':  # Amp + j 0
             data.real *= np.real(complex_data.conj()/abs(complex_data))
 
-        if self.data_type in ['amp-pha', 'phase']:
+        elif self.data_type == 'phase':    # 0 + j Pha
             data.imag *= np.real(-1j*complex_data.conj()/abs(complex_data)**2)
 
     def center_abs(self, source):
@@ -691,10 +690,13 @@ class RxElectricPoint(Receiver, Point):
         complex values, but the meaning of the real and imaginary part differs
         depending on the data type. Currently implemented are:
 
-        - ``'complex'``: Complex values: Real + j Imag
-        - ``'amp-pha'``: Amplitude and phase: Amplitude + j Phase
-        - ``'amplitude'``: Amplitude and phase: Amplitude + j 0
-        - ``'phase'``: Amplitude and phase: 0 + j Phase
+        - ``'complex'``: Complex values:        Real + j Imag
+        - ``'amplitude'``: Amplitude and phase:  Amp + j 0
+        - ``'phase'``: Amplitude and phase:        0 + j Pha
+
+        The preferred choice is complex, but the latter two are implemented for
+        the case where phase or amplitude information is not available or very
+        poor.
 
     """
     _adjoint_source = TxElectricPoint
@@ -731,10 +733,13 @@ class RxMagneticPoint(Receiver, Point):
         complex values, but the meaning of the real and imaginary part differs
         depending on the data type. Currently implemented are:
 
-        - ``'complex'``: Complex values: Real + j Imag
-        - ``'amp-pha'``: Amplitude and phase: Amplitude + j Phase
-        - ``'amplitude'``: Amplitude and phase: Amplitude + j 0
-        - ``'phase'``: Amplitude and phase: 0 + j Phase
+        - ``'complex'``: Complex values:        Real + j Imag
+        - ``'amplitude'``: Amplitude and phase:  Amp + j 0
+        - ``'phase'``: Amplitude and phase:        0 + j Pha
+
+        The preferred choice is complex, but the latter two are implemented for
+        the case where phase or amplitude information is not available or very
+        poor.
 
     """
     _adjoint_source = TxMagneticPoint

--- a/emg3d/simulations.py
+++ b/emg3d/simulations.py
@@ -999,6 +999,7 @@ class Simulation:
 
         # Get values for this source and frequency.
         grid = self.get_grid(source, frequency)
+        synthetic = self.data.synthetic.loc[source, :, frequency].data
         residual = self.data.residual.loc[source, :, frequency].data
         weight = self.data.weights.loc[source, :, frequency].data
 
@@ -1014,6 +1015,9 @@ class Simulation:
             # Skip if no data.
             if np.isnan(residual[i]):
                 continue
+
+            # Apply chain rule to strength if data_type != complex.
+            rec.derivative_chain(strength[i], synthetic[i])
 
             # Get absolute coordinates as fct of source.
             # (Only relevant in case of "relative" receivers.)

--- a/emg3d/simulations.py
+++ b/emg3d/simulations.py
@@ -720,10 +720,11 @@ class Simulation:
             # Store responses at receiver locations.
             resp = self._get_responses(src, freq)
             if self.survey._anyrec_non_complex:
+                syn = np.zeros_like(self.data.synthetic.loc[src, :, freq])
+                for i, rec in enumerate(self.survey.receivers.values()):
+                    syn[i] = rec.from_complex(resp[i])
+                self.data['synthetic'].loc[src, :, freq] = syn
                 self.data['complex'].loc[src, :, freq] = resp
-                for i, dat in enumerate(resp):
-                    syn = self.survey.receivers.values()[i].from_complex(dat)
-                    self.data['synthetic'].loc[src, i, freq] = syn
             else:
                 self.data['synthetic'].loc[src, :, freq] = resp
 

--- a/emg3d/simulations.py
+++ b/emg3d/simulations.py
@@ -210,7 +210,7 @@ class Simulation:
         # Sets self.model and self.gridding_opts.
         self._set_model(model, kwargs)
 
-        # Initiate complex and synthetic data with NaN's if they don't exist.
+        # Initiate synthetic and complex data with NaN's if they don't exist.
         if 'synthetic' not in self.survey.data.keys():
             self.survey._data['synthetic'] = self.data.observed.copy(
                     data=np.full(self.survey.shape, np.nan+1j*np.nan))
@@ -736,9 +736,9 @@ class Simulation:
             # Add noise.
             if kwargs.get('add_noise', True):
 
-                # TODO
+                # Ensure there are no non-complex data.
                 if self.survey._anyrec_non_complex:
-                    msg = "Add noise only implemented for complex data."
+                    msg = "`add_noise` is only implemented for complex data."
                     raise NotImplementedError(msg)
 
                 self.survey.add_noise(**kwargs)

--- a/emg3d/surveys.py
+++ b/emg3d/surveys.py
@@ -681,14 +681,6 @@ class Survey:
             self._anyrec_non_complex_bool = any(cmpl)
         return self._anyrec_non_complex_bool
 
-    @property
-    def _anyrec_amp_pha(self):
-        """Boolean if any receiver has data_type amp-pha."""
-        if getattr(self, '_anyrec_amp_pha_bool', None) is None:
-            ampha = [r.data_type == 'amp-pha' for r in self.receivers.values()]
-            self._anyrec_amp_pha_bool = any(ampha)
-        return self._anyrec_amp_pha_bool
-
 
 def random_noise(standard_deviation, mean_noise=0.0, ntype='white_noise'):
     r"""Return random noise for given inputs.

--- a/emg3d/surveys.py
+++ b/emg3d/surveys.py
@@ -93,6 +93,10 @@ class Survey:
 
         If None, it will be initiated with NaN's.
 
+        Data can be provided in different formats, which are defined when
+        creating receiver instances. Consult their documentation for more info;
+        default is always ``'complex'``.
+
     noise_floor, relative_error : {float, ndarray}, default: None
         Noise floor and relative error of the data. They can be arrays of a
         shape which can be broadcasted to the data shape, e.g., (nsrc, 1, 1) or
@@ -668,6 +672,22 @@ class Survey:
         # Return per receiver type (erec, mrec).
         indices = self._irec_types
         return [tuple(self._rec_coord[source][ind].T) for ind in indices]
+
+    @property
+    def _anyrec_non_complex(self):
+        """Boolean if any receiver has another data_type than complex."""
+        if getattr(self, '_anyrec_non_complex_bool', None) is None:
+            cmpl = [r.data_type != 'complex' for r in self.receivers.values()]
+            self._anyrec_non_complex_bool = any(cmpl)
+        return self._anyrec_non_complex_bool
+
+    @property
+    def _anyrec_amp_pha(self):
+        """Boolean if any receiver has data_type amp-pha."""
+        if getattr(self, '_anyrec_amp_pha_bool', None) is None:
+            ampha = [r.data_type == 'amp-pha' for r in self.receivers.values()]
+            self._anyrec_amp_pha_bool = any(ampha)
+        return self._anyrec_amp_pha_bool
 
 
 def random_noise(standard_deviation, mean_noise=0.0, ntype='white_noise'):

--- a/tests/test_electrodes.py
+++ b/tests/test_electrodes.py
@@ -299,8 +299,8 @@ def test_receiver():
     rcoo = [1000, -200, 0]
     scoo = [50, 50, 50, 0, 0]
 
-    ra = electrodes.Receiver(False, coordinates=rcoo)
-    rr = electrodes.Receiver(True, coordinates=rcoo)
+    ra = electrodes.Receiver(False, coordinates=rcoo, data_type='complex')
+    rr = electrodes.Receiver(True, coordinates=rcoo, data_type='complex')
     s1 = electrodes.TxElectricDipole(coordinates=scoo)
 
     assert ra.relative is False


### PR DESCRIPTION
- [x] Add to receivers the method `.data_type`
  - `complex`
  - `amplitude`
  - `phase` 
- [x] Add to receivers the method `.derivative_chain`  
- [x] Add a `data.complex` data set:
  - `data.complex` contains always the complex data
  - `data.synthetic` contains data in the form of `data_type`, which is the same type as `data.observed`
- [x] Add to receivers the method `.from_complex`; this can be used to obtain the data in the form of `data_type` from complex data: `rec.from_complex(data)`.
- [x] These changes have to be implemented throughout the `Simulation` class.
- [ ] Verify implementation and add tests!
