### PR TITLE
domain/distant to cut vector

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,10 +6,24 @@ Changelog
 """"""""""
 
 
-latest
-------
+*latest* will become v1.4.0
+---------------------------
+
+- Meshes: Non-backwards compatible change in ``construct_mesh``
+  (``origin_and_widths``; ``estimate_gridding_options``). It is implemented
+  non-backwards compatible as the old rules were not intuitive nor logic. The
+  previous meshes can still be obtained by setting the parameters carefully.
+  - Priority-order changed to ``domain > distance > vector`` (before it was
+    ``domain > vector > distance``).
+  - A ``vector`` is new cut to the corresponding domain, if ``domain`` or
+    ``distance`` was defined as well (cut at the first point where
+    ``vector <= domain[0]``, ``vector >= domain[1]``).
 
 - Removed functions and modules that were deprecated in v1.2.1.
+
+- Bugfix when adding ``add_noise`` explicitly to ``Simulation.compute()``.
+
+- Maintenance: Python 3.10 added to tests; Python 3.7 reduced to minimum.
 
 
 v1.3.2: Bugfix CLI-select

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,11 +104,14 @@ html_css_files = [
 
 # ==== 4. linkcheck ====
 
-# Papers from academic.oup results in a 104 error
+# Papers from academic.oup result in a 104 Error?
+# Papers from PIERS result in a 404 Client Error?
 linkcheck_ignore = [
     'https://doi.org/10.1111/j.1365-246X.2010.04544.x',
     'https://doi.org/10.1088/0266-5611/24/3/034012',
     'https://doi.org/10.1093/gji/ggab171',
+    'https://doi.org/10.2528/PIER10052807',
+    'https://doi.org/10.2528/PIER00080103',
     'https://www.terrasysgeo.com',
     'https://www.pygimli.org',
 ]

--- a/docs/manual/references.rst
+++ b/docs/manual/references.rst
@@ -56,7 +56,7 @@ References
    <https://doi.org/10.1088/0266-5611/24/3/034012>`_.
 .. [SlHM10] Slob, E., J. Hunziker, and W. A. Mulder, 2010, Green's tensors for
    the diffusive electric field in a VTI half-space: PIER, 107, 1--20: DOI:
-   `10.2528/PIER10052807 <http://doi.org/10.2528/PIER10052807>`_.
+   `10.2528/PIER10052807 <https://doi.org/10.2528/PIER10052807>`_.
 .. [Weil77] Weiland, T., 1977, Eine Methode zur Lösung der Maxwellschen
    Gleichungen für sechskomponentige Felder auf diskreter Basis: Archiv für
    Elektronik und Übertragungstechnik, 31, 116--120; pdf:

--- a/emg3d/meshes.py
+++ b/emg3d/meshes.py
@@ -623,11 +623,11 @@ def origin_and_widths(frequency, properties, center, domain=None, vector=None,
             "and `vector` must be provided."
         )
     elif domain is None:
-        if vector is None:
+        if distance is None:
+            domain = np.array([vector.min(), vector.max()], dtype=float)
+        else:
             domain = np.array([center-abs(distance[0]),
                                center+abs(distance[1])])
-        else:
-            domain = np.array([vector.min(), vector.max()], dtype=float)
     else:
         domain = np.array(domain, dtype=np.float64)
         if vector is not None:
@@ -1270,16 +1270,16 @@ def estimate_gridding_opts(gridding_opts, model, survey, input_sc2=None):
             diff = np.diff(dim)[0]
             get_it = False
 
-        elif vector is not None and vector[i] is not None:
-            # vector is provided.
-            dim = [np.min(vector[i]), np.max(vector[i])]
-            diff = np.diff(dim)[0]
-            get_it = False
-
         elif distance is not None and distance[i] is not None:
             # distance is provided.
             dim = None
             diff = abs(distance[i][0]) + abs(distance[i][1])
+            get_it = False
+
+        elif vector is not None and vector[i] is not None:
+            # vector is provided.
+            dim = [np.min(vector[i]), np.max(vector[i])]
+            diff = np.diff(dim)[0]
             get_it = False
 
         else:

--- a/emg3d/meshes.py
+++ b/emg3d/meshes.py
@@ -637,6 +637,16 @@ def origin_and_widths(frequency, properties, center, domain=None, vector=None,
                     "all of the survey domain."
                 )
 
+    # TODO make this optional per keyword
+    if vector is not None:  # and domain_dominates = True:
+        vmin = np.where(vector <= domain[0])[0]
+        if vmin.size > 1:
+            vector = vector[vmin[-1]:]
+
+        vmax = np.where(vector >= domain[1])[0]
+        if vmax.size > 1:
+            vector = vector[:vmax[1]]
+
     # Seasurface related checks.
     if seasurface is not None:
 

--- a/tests/test_meshes.py
+++ b/tests/test_meshes.py
@@ -311,13 +311,20 @@ class TestOriginAndWidths:
         assert "2.98 / 3.00 / 3.02  [corr. to `properties`]" in out
 
     def test_domain_vector(self):
-        x01, hx1 = meshes.origin_and_widths(
-                1/np.pi, 9*mu_0, 0.0, [-1, 1], stretching=[1, 1])
-        x02, hx2 = meshes.origin_and_widths(
-                1/np.pi, 9*mu_0, 0.0, vector=np.array([-1, 0, 1]),
-                stretching=[1, 1])
+        inp = {'frequency': 1/np.pi, 'properties': 9*mu_0, 'center': 0.0,
+               'stretching': [1, 1]}
+        x01, hx1 = meshes.origin_and_widths(domain=[-1, 1], **inp)
+        x02, hx2 = meshes.origin_and_widths(vector=np.array([-1, 0, 1]), **inp)
+        x03, hx3 = meshes.origin_and_widths(  # vector will be cut
+                domain=[-1, 1], vector=np.array([-2, -1, 0, 1, 2]), **inp)
+        x04, hx4 = meshes.origin_and_widths(  # vector will be cut
+                distance=[1, 1], vector=np.array([-2, -1, 0, 1, 2]), **inp)
         assert_allclose(x01, x02)
+        assert_allclose(x01, x03)
+        assert_allclose(x01, x04)
         assert_allclose(hx1, hx2)
+        assert_allclose(hx1, hx3)
+        assert_allclose(hx1, hx4)
 
         x03, hx3 = meshes.origin_and_widths(
                 1/np.pi, 9*mu_0, 0.0, distance=[1, 1], stretching=[1, 1])
@@ -378,10 +385,10 @@ class TestOriginAndWidths:
         assert "Skin depth     [m] : 620 / 1125 / 50" in out
         assert "Survey dom. DS [m] : -2000 - -1000" in out
         assert "Comp. dom. DC  [m] : -10950 - 5300" in out
-        assert "Final extent   [m] : -13850 - 5386" in out
-        assert "Cell widths    [m] : 100 / 100 / 3158" in out
-        assert "Number of cells    : 40 (20 / 20 / 0)" in out
-        assert "Max stretching     : 1.000 (1.000) / 1.369" in out
+        assert "Final extent   [m] : -11118 - 6651" in out
+        assert "Cell widths    [m] : 100 / 100 / 1968" in out
+        assert "Number of cells    : 40 (15 / 25 / 0)" in out
+        assert "Max stretching     : 1.000 (1.000) / 1.258" in out
 
         # High frequencies.
         _, _, out = meshes.origin_and_widths(


### PR DESCRIPTION
Currently, a provided `vector` is taken _as is_, ignoring `domain` or `distance`. This PR changes this, so that a `vector` is cut according to `domain` and `distance`, if provided. Additional, priority changes from ``domain > vector > distance`` to ``domain > distance > vector``.