### PR TITLE
Bugfixes, many; plus add_noise in CLI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,19 @@ Changelog
 latest
 ------
 
+- CLI takes new the boolean ``add_noise`` in the section ``[noise_opts]``
+  (default is True).
+
+- Bug fixes / tiny improvements
+
+  - Simulation.misfit returns an ndarray again instead of an DataArray (was
+    erroneously changed in v1.2.1).
+  - Write json can now handle NumPy int/bool/float.
+  - A clean on a Simulation now removes correctly the weights.
+  - Capture error in jtvec if weight is complex NaN (should be real).
+  - Model: ``mapping`` can now be an already instantiated map (sort of
+    undocumented).
+
 - Maintenance
 
   - Replace ``pytest-flake8`` by plain ``flake8``.

--- a/docs/manual/cli.rst
+++ b/docs/manual/cli.rst
@@ -121,6 +121,7 @@ remove the comment signs to use them.
   # Only if `--forward`, the noise options are passed to
   # `Simulation.compute(observed=True, **noise_opts)`.
   [noise_opts]
+  # add_noise = True      # Set to False to switch noise off.
   # min_offset = 0.0      # off < min_off set to NaN.
   # max_offset = np.infty # off > max_off set to NaN.
   # mean_noise = 0.0      # Mean of the noise.

--- a/emg3d/cli/main.py
+++ b/emg3d/cli/main.py
@@ -145,6 +145,14 @@ def main(args=None):
         help="replace model and all computed data of loaded simulation"
     )
 
+    # arg: Run without emg3d-computation.
+    parser.add_argument(
+        "-d", "--dry-run",
+        action="store_true",
+        default=False,
+        help="only display what would have been done"
+    )
+
     # arg: Verbosity.
     group3 = parser.add_mutually_exclusive_group()
     group3.add_argument(
@@ -166,14 +174,6 @@ def main(args=None):
         const=-1,
         dest="verbosity",
         help="decrease verbosity"
-    )
-
-    # arg: Run without emg3d-computation.
-    parser.add_argument(
-        "-d", "--dry-run",
-        action="store_true",
-        default=False,
-        help="only display what would have been done"
     )
 
     # arg: Report

--- a/emg3d/cli/parser.py
+++ b/emg3d/cli/parser.py
@@ -240,6 +240,10 @@ def parse_config_file(args_dict):
         if cfg.has_option('noise_opts', key):
             _ = all_noise.pop(key)
             noise_kwargs[key] = cfg.get('noise_opts', key)
+        key = 'add_noise'
+        if cfg.has_option('noise_opts', key):
+            _ = all_noise.pop(key)
+            noise_kwargs[key] = cfg.getboolean('noise_opts', key)
 
         # Ensure no keys are left.
         if all_noise:

--- a/emg3d/io.py
+++ b/emg3d/io.py
@@ -418,6 +418,10 @@ def _dict_unflatten(data):
 def _dict_dearray_decomp(data):
     """Return dict where arrays are replaced by lists, complex by real numbers.
 
+    Note:
+    This would better be implemented with a custom json.JSONEncoder. However,
+    here we add the '__complex'- and '__array'-flags, so we can re-construct
+    them when loading the json.
 
     Parameters
     ----------
@@ -452,6 +456,18 @@ def _dict_dearray_decomp(data):
         if isinstance(value, np.ndarray):
             key += '__array-'+value.dtype.name
             value = value.tolist()
+
+        # Convert numpy ints.
+        if isinstance(value, np.integer):
+            value = int(value)
+
+        # Convert NumPy floats.
+        if isinstance(value, np.floating):
+            value = float(value)
+
+        # Convert NumPy booleans.
+        if isinstance(value, np.bool_):
+            value = bool(value)
 
         # Store this key-value-pair.
         out[key] = value

--- a/emg3d/simulations.py
+++ b/emg3d/simulations.py
@@ -344,7 +344,7 @@ class Simulation:
 
         # Clean data.
         if what in ['computed', 'all']:
-            for key in ['residual', 'weight']:
+            for key in ['residual', 'weights']:
                 if key in self.data.keys():
                     del self.data[key]
             self.data['synthetic'] = self.data.observed.copy(
@@ -1042,7 +1042,7 @@ class Simulation:
             weights = self.data['weights']
             self._misfit = np.sum(weights*(residual.conj()*residual)).real/2
 
-        return self._misfit
+        return self._misfit.data
 
     def _bcompute(self):
         """Compute bfields asynchronously for all sources and frequencies."""
@@ -1266,7 +1266,8 @@ class Simulation:
 
         # Replace residual by provided vector
         # (division by weight is undone in gradient).
-        self.data.residual[...] = vector/self.data.weights.data
+        with np.errstate(invalid='ignore'):  # (For division by cplx-NaN.)
+            self.data.residual[...] = vector/self.data.weights.data
 
         # Reset gradient, so it will be computed.
         self._gradient = None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -309,6 +309,7 @@ class TestParser:
         config = os.path.join(tmpdir, 'emg3d.cfg')
         with open(config, 'w') as f:
             f.write("[noise_opts]\n")
+            f.write("add_noise=True\n")
             f.write("min_offset=1320\n")
             f.write("max_offset=5320\n")
             f.write("mean_noise=1.0\n")
@@ -318,6 +319,7 @@ class TestParser:
         args_dict['config'] = config
         cfg, term = cli.parser.parse_config_file(args_dict)
         noise_kwargs = cfg['noise_kwargs']
+        assert noise_kwargs['add_noise']
         assert noise_kwargs['min_offset'] == 1320.0
         assert noise_kwargs['max_offset'] == 5320.0
         assert noise_kwargs['mean_noise'] == 1.0

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -226,6 +226,22 @@ def test_dict_dearray_decomp_array_comp():
     assert_allclose(d1, data['d1'])
     assert_allclose(d2, data['d3']['d2'])
 
+    # Test added np formats.
+    deac = io._dict_dearray_decomp({
+        'int': np.int64(0),
+        'bool': np.bool_(True),
+        'float': np.float32(2.0),
+    })
+
+    assert isinstance(deac['int'], int)
+    assert isinstance(deac['bool'], bool)
+    assert isinstance(deac['float'], float)
+
+    data = io._dict_array_comp(deac)
+    assert data['int'] == 0
+    assert data['bool']
+    assert data['float'] == 2.0
+
 
 def test_hdf5_dump_load(tmpdir):
     d1 = np.arange(10)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -194,7 +194,8 @@ class TestModel:
                 np.zeros(3))
 
         model1 = models.Model(grid)
-        model2 = models.Model(grid, mapping='Conductivity')
+        mapping = emg3d.maps.MapConductivity()
+        model2 = models.Model(grid, mapping=mapping)
 
         check = model1 == model2
 

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -206,11 +206,16 @@ class TestSimulation():
 
         # Clean and ensure it is empty
         sim3 = self.simulation.copy()
+        _ = sim3.misfit
         sim3.clean('all')
         assert sim3._dict_efield['TxMD-2']['f-1'] is None
         assert sim3._dict_efield_info['TxMD-2']['f-1'] is None
         with pytest.raises(TypeError, match="Unrecognized `what`: nothing"):
             sim3.clean('nothing')
+        with pytest.raises(AttributeError, match="no attribute 'weights'"):
+            sim3.data.weights
+        with pytest.raises(AttributeError, match="no attribute 'residuals'"):
+            sim3.data.residuals
 
     def test_dicts_provided(self):
         grids = self.simulation._dict_grid.copy()


### PR DESCRIPTION
- CLI takes new the boolean ``add_noise`` in the section ``[noise_opts]``
  (default is True).

- Bug fixes / tiny improvements

  - Simulation.misfit returns an ndarray again instead of an DataArray (was
    erroneously changed in v1.2.1).
  - Write json can now handle NumPy int/bool/float.
  - A clean on a Simulation now removes correctly the weights.
  - Capture error in jtvec if weight is complex NaN (should be real).
  - Model: ``mapping`` can now be an already instantiated map (sort of
    undocumented).
