### PR TITLE
Maintenance

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,31 +31,31 @@ jobs:
       matrix:
         os: [ubuntu, ]  # macos, windows]  # Only Linux currently.
         case:
-          - python-version: "3.7"
+          - python-version: "3.8"
             name: minimal
             os: ubuntu
-            conda: "'scipy=1.4' 'numpy=1.17' 'numba=0.45'"
-          - python-version: "3.8"
+            conda: "'scipy=1.5' 'numpy=1.19' 'numba=0.50'"
+          - python-version: "3.9"
             name: full
             os: ubuntu
             conda: "numba scipy xarray empymod h5py scooby discretize matplotlib"  # tqdm
-          - python-version: "3.8"
-            name: plain
-            os: ubuntu
-            conda: "numba scipy"
           - python-version: "3.9"
             name: plain
             os: ubuntu
             conda: "numba scipy"
-          - python-version: "3.9"
+          - python-version: "3.10"
+            name: plain
+            os: ubuntu
+            conda: "numba scipy"
+          - python-version: "3.10"
             name: full
             os: ubuntu
             conda: "numba scipy xarray tqdm empymod h5py scooby discretize matplotlib"
-          - python-version: "3.10"
+          - python-version: "3.11"
             name: plain
             os: ubuntu
             conda: "numba scipy"
-          - python-version: "3.10"
+          - python-version: "3.11"
             name: full
             os: ubuntu
             conda: "numba scipy xarray tqdm empymod h5py scooby discretize matplotlib"
@@ -120,7 +120,7 @@ jobs:
       - name: Test with pytest
         shell: bash -l {0}
         run: |
-          python setup.py install
+          pip install --no-build-isolation --no-deps .
           pytest --cov=emg3d
 
       - name: Coveralls

--- a/.github/workflows/macos_windows.yml
+++ b/.github/workflows/macos_windows.yml
@@ -83,5 +83,5 @@ jobs:
       - name: Test with pytest
         shell: bash -l {0}
         run: |
-          python setup.py install
+          pip install --no-build-isolation --no-deps .
           pytest

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,6 +13,8 @@ formats: []
 python:
   version: 3.8
   install:
+    # Temporary workaround to have discretize wheels built.
+    - requirements: .rtd-requirements.txt
     - requirements: requirements-dev.txt
     - method: pip
       path: .

--- a/.rtd-requirements.txt
+++ b/.rtd-requirements.txt
@@ -1,0 +1,4 @@
+# Temporary workaround to have discretize wheels built.
+numpy
+cython
+

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,14 +6,29 @@ Changelog
 """"""""""
 
 
-latest
-------
+v1.8.2 : convert & pip-full
+---------------------------
+
+**2023-05-31**
 
 
 - ``io``: New function ``convert`` to convert a file that was saved with emg3d
-  to another file format.
+  from one file format to another file format.
 - Installation through pip has new the option ``pip install emg3d[full]``,
   which installs all soft dependencies as well.
+
+- Bumped the minimum requirements to:
+
+  - Python 3.8
+  - NumPy 1.19
+  - SciPy 1.5
+  - Numba 0.50
+
+- Bug fixes, small improvements and maintenance
+
+  - Testing: added Python 3.11, dropped Python 3.7.
+  - Adjust copyright notice to only include original year, so it has not to be
+    adjusted each year.
 
 
 v1.8.1 : Bugfix ellipse

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@
 .. image:: https://img.shields.io/conda/v/conda-forge/emg3d.svg
    :target: https://anaconda.org/conda-forge/emg3d/
    :alt: conda-forge
-.. image:: https://img.shields.io/badge/python-3.7+-blue.svg
+.. image:: https://img.shields.io/badge/python-3.8+-blue.svg
    :target: https://www.python.org/downloads/
    :alt: Supported Python Versions
 .. image:: https://img.shields.io/badge/platform-linux,win,osx-blue.svg

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-import time
 from emg3d import __version__
 
 # ==== 1. Extensions  ====
@@ -57,7 +56,7 @@ master_doc = 'index'
 # General information about the project.
 project = 'emg3d'
 author = 'The emsig community'
-copyright = f'2018-{time.strftime("%Y")}, {author}'
+copyright = f'2018, {author}'
 
 # |version| and |today| tags (|release|-tag is not used).
 version = __version__
@@ -103,17 +102,9 @@ html_css_files = [
 
 # ==== 4. linkcheck ====
 
-# Many journals do not allow the ping (???)
+# Many journals do not allow the ping; no idea why. I exclude all DOI's from
+# the check; they "should" be permanent, that is their entire purpose; doi.org
+# is responsible for resolving them.
 linkcheck_ignore = [
-    'https://doi.org/10.1111/j.1365-246X.2010.04544.x',
-    'https://doi.org/10.1088/0266-5611/24/3/034012',
-    'https://doi.org/10.1093/gji/ggab171',
-    'https://doi.org/10.2528/PIER10052807',
-    'https://doi.org/10.2528/PIER00080103',
-    'https://doi.org/10.1137/0731021',
-    'https://doi.org/10.1137/1.9780898719505',
-    'https://doi.org/10.1111/j.1365-2478.2010.00899.x',
-    'https://doi.org/10.1111/j.1365-2478.2006.00558.x',
-    'https://www.terrasysgeo.com',
-    'https://www.pygimli.org',
+    "https://doi.org/10.*",
 ]

--- a/docs/manual/installation.rst
+++ b/docs/manual/installation.rst
@@ -13,7 +13,7 @@ or via ``pip``:
 
    pip install emg3d
 
-Minimum requirements are Python version 3.7 or higher and the modules ``scipy``
+Minimum requirements are Python version 3.8 or higher and the modules ``scipy``
 and ``numba``. Various other packages are recommended or required for some
 advanced functionalities, namely:
 

--- a/docs/manual/license.rst
+++ b/docs/manual/license.rst
@@ -18,7 +18,7 @@ This work is licensed under Attribution 4.0 International (CC-BY-4.0).
 License of Code
 ---------------
 
-Copyright 2018-2023 The emsig community.
+Copyright 2018 The emsig community.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/emg3d/__init__.py
+++ b/emg3d/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 The emsig community.
+# Copyright 2018 The emsig community.
 #
 # This file is part of emg3d.
 #

--- a/emg3d/__main__.py
+++ b/emg3d/__main__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 The emsig community.
+# Copyright 2018 The emsig community.
 #
 # This file is part of emg3d.
 #

--- a/emg3d/_multiprocessing.py
+++ b/emg3d/_multiprocessing.py
@@ -1,7 +1,7 @@
 """
 Helper routines to call functions with multiprocessing/concurrent.futures.
 """
-# Copyright 2018-2023 The emsig community.
+# Copyright 2018 The emsig community.
 #
 # This file is part of emg3d.
 #

--- a/emg3d/cli/__init__.py
+++ b/emg3d/cli/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 The emsig community.
+# Copyright 2018 The emsig community.
 #
 # This file is part of emg3d.
 #

--- a/emg3d/cli/main.py
+++ b/emg3d/cli/main.py
@@ -1,7 +1,7 @@
 """
 Entry point for the command-line interface (CLI).
 """
-# Copyright 2018-2023 The emsig community.
+# Copyright 2018 The emsig community.
 #
 # This file is part of emg3d.
 #

--- a/emg3d/cli/parser.py
+++ b/emg3d/cli/parser.py
@@ -1,7 +1,7 @@
 """
 Parser for the configuration file of the command-line interface.
 """
-# Copyright 2018-2023 The emsig community.
+# Copyright 2018 The emsig community.
 #
 # This file is part of emg3d.
 #

--- a/emg3d/cli/run.py
+++ b/emg3d/cli/run.py
@@ -1,7 +1,7 @@
 """
 Functions that actually call emg3d within the CLI interface.
 """
-# Copyright 2018-2023 The emsig community.
+# Copyright 2018 The emsig community.
 #
 # This file is part of emg3d.
 #

--- a/emg3d/core.py
+++ b/emg3d/core.py
@@ -20,7 +20,7 @@ For a developer interested in making emg3d faster this is the right place to
 start, as by far the most time is spent in these functions, particularly in
 :func:`solve`.
 """
-# Copyright 2018-2023 The emsig community.
+# Copyright 2018 The emsig community.
 #
 # This file is part of emg3d.
 #

--- a/emg3d/electrodes.py
+++ b/emg3d/electrodes.py
@@ -1,7 +1,7 @@
 """
 Electrodes define any type of sources and receivers used in a survey.
 """
-# Copyright 2018-2023 The emsig community.
+# Copyright 2018 The emsig community.
 #
 # This file is part of emg3d.
 #

--- a/emg3d/fields.py
+++ b/emg3d/fields.py
@@ -3,7 +3,7 @@ Everything that is related to fields: storing the electric field, obtaining the
 magnetic field, generating the source field; obtaining the fields at receiver
 locations.
 """
-# Copyright 2018-2023 The emsig community.
+# Copyright 2018 The emsig community.
 #
 # This file is part of emg3d.
 #

--- a/emg3d/io.py
+++ b/emg3d/io.py
@@ -1,7 +1,7 @@
 """
 Utility functions for writing and reading data.
 """
-# Copyright 2018-2023 The emsig community.
+# Copyright 2018 The emsig community.
 #
 # This file is part of emg3d.
 #
@@ -227,8 +227,7 @@ def convert(ifname, ofname, **kwargs):
     Parameters
     ----------
     ifname, ofname : str
-        {Input;Output} file name with absolute or relative path including
-        suffix, which defines the used data format. Implemented are currently:
+        {Input;Output} file names (absolute or relative path) including suffix.
 
     """
     data = load(ifname, **kwargs)

--- a/emg3d/maps.py
+++ b/emg3d/maps.py
@@ -5,7 +5,7 @@ thereof.
 
 Interpolation routines mapping values between different grids.
 """
-# Copyright 2018-2023 The emsig community.
+# Copyright 2018 The emsig community.
 #
 # This file is part of emg3d.
 #

--- a/emg3d/meshes.py
+++ b/emg3d/meshes.py
@@ -1,7 +1,7 @@
 """
 Everything related to meshes appropriate for the multigrid solver.
 """
-# Copyright 2018-2023 The emsig community.
+# Copyright 2018 The emsig community.
 #
 # This file is part of emg3d.
 #

--- a/emg3d/models.py
+++ b/emg3d/models.py
@@ -1,7 +1,7 @@
 """
 Everything to store electromagnetic material properties for the solver.
 """
-# Copyright 2018-2023 The emsig community.
+# Copyright 2018 The emsig community.
 #
 # This file is part of emg3d.
 #

--- a/emg3d/simulations.py
+++ b/emg3d/simulations.py
@@ -5,7 +5,7 @@ due to a given model and survey.
 The simulation module combines the different pieces of ``emg3d`` providing
 a high-level, specialised modelling tool for the end user.
 """
-# Copyright 2018-2023 The emsig community.
+# Copyright 2018 The emsig community.
 #
 # This file is part of emg3d.
 #

--- a/emg3d/solver.py
+++ b/emg3d/solver.py
@@ -10,7 +10,7 @@ you are interested in understanding how the multigrid solver works, the theory
 and its implementation.
 
 """
-# Copyright 2018-2023 The emsig community.
+# Copyright 2018 The emsig community.
 #
 # This file is part of emg3d.
 #

--- a/emg3d/surveys.py
+++ b/emg3d/surveys.py
@@ -2,7 +2,7 @@
 A survey stores a set of sources and their frequencies, receivers, and the
 measured data.
 """
-# Copyright 2018-2023 The emsig community.
+# Copyright 2018 The emsig community.
 #
 # This file is part of emg3d.
 #

--- a/emg3d/time.py
+++ b/emg3d/time.py
@@ -1,7 +1,7 @@
 """
 Functionalities related to time-domain modelling using a frequency-domain code.
 """
-# Copyright 2018-2023 The emsig community.
+# Copyright 2018 The emsig community.
 #
 # This file is part of emg3d.
 #

--- a/emg3d/utils.py
+++ b/emg3d/utils.py
@@ -1,7 +1,7 @@
 """
 Utility functions for the multigrid solver.
 """
-# Copyright 2018-2023 The emsig community.
+# Copyright 2018 The emsig community.
 #
 # This file is part of emg3d.
 #

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ import re
 import sys
 from setuptools import setup
 
-if not sys.version_info[:2] >= (3, 7):
-    sys.exit(f"emg3d is only meant for Python 3.7 and up.\n"
+if not sys.version_info[:2] >= (3, 8):
+    sys.exit(f"emg3d is only meant for Python 3.8 and up.\n"
              f"Current version: {sys.version_info[0]}.{sys.version_info[1]}.")
 
 # Get README and remove badges.
@@ -24,20 +24,20 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     entry_points={
         "console_scripts": [
             "emg3d=emg3d.cli.main:main",
         ],
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
-        "scipy>=1.4",
-        "numba>=0.45",
+        "scipy>=1.5",
+        "numba>=0.50",
     ],
     extras_require={
         'full': [

--- a/tests/alternatives.py
+++ b/tests/alternatives.py
@@ -13,7 +13,7 @@ can use them for cross-checking with the main code. Also, they might (or might
 not) be easier to understand.
 
 """
-# Copyright 2018-2023 The emsig community.
+# Copyright 2018 The emsig community.
 #
 # This file is part of emg3d.
 #

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,11 +64,11 @@ def test_main(script_runner):
     assert "* ERROR   :: Config file not found: " in ret.stderr
 
 
-# Skip test for 3.7, it fails. Not sure why.
+# Skip test for minimal, it fails. Not sure why.
 # Something multiprocessing/numba/sem_open/synchronization primitives.
 @disable_numba()
 @pytest.mark.script_launch_mode('subprocess')
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="Exclude for Python 3.7")
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="Exclude for Python 3.8")
 def test_main2(script_runner):
 
     # Test emg3d/__main__.py by calling the folder emg3d.

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -55,7 +55,7 @@ class TestFourier:
 
     def test_kwargs(self):
         times = np.logspace(-1, 1)
-        fmin = 0.1
+        fmin = 0.1 - np.finfo(float).eps
         fmax = 10
         input_freq = np.logspace(-1, 1, 11)
         xfreq = 10

--- a/tests/unused.py
+++ b/tests/unused.py
@@ -7,7 +7,7 @@ These are unused code snippets that might come in handy at some point, maybe
 even just for testing purposes.
 
 """
-# Copyright 2018-2023 The emsig community.
+# Copyright 2018 The emsig community.
 #
 # This file is part of emg3d.
 #


### PR DESCRIPTION
- Fix doc-typo in `io.convert`
- Fix test errors
- Add Python 3.11; remove Python 3.7
- Adjust ignored links
- Simplify copyright statement
- ...

Closes, among other, #315 