### PR TITLE
pyGIMLi(emg3d)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -40,30 +40,37 @@ jobs:
             name: minimal
             os: ubuntu
             conda: "'scipy=1.9' 'numba=0.53' 'numpy<2.0' 'empymod>=2.3'"
+            pip : "scooby"  # to not be empty
           - python-version: "3.10"
             name: full
             os: ubuntu
             conda: "numba scipy xarray h5py discretize matplotlib 'numpy<2.0' 'empymod>=2.3'"  # tqdm
+            pip : "scooby"  # to not be empty
           - python-version: "3.10"
             name: plain
             os: ubuntu
             conda: "numba scipy 'numpy<2.0' 'empymod>=2.3'"
+            pip : "scooby"  # to not be empty
           - python-version: "3.11"
             name: plain
             os: ubuntu
             conda: "numba scipy 'numpy<2.0' 'empymod>=2.3'"
+            pip : "scooby"  # to not be empty
           - python-version: "3.11"
             name: full
             os: ubuntu
             conda: "numba scipy xarray tqdm h5py discretize matplotlib 'numpy<2.0' 'empymod>=2.3'"
+            pip : "scooby pygimli"  # to not be empty
           - python-version: "3.12"
             name: plain
             os: ubuntu
             conda: "numba scipy 'numpy<2.0' 'empymod>=2.3'"
+            pip : "scooby"  # to not be empty
           - python-version: "3.12"
             name: full
             os: ubuntu
             conda: "numba scipy xarray tqdm h5py discretize matplotlib 'numpy<2.0' 'empymod>=2.3'"
+            pip : "scooby"  # to not be empty
 
     env:
       # Used for coveralls flag
@@ -106,6 +113,7 @@ jobs:
           conda config --show
           conda info -a
           conda install ${{ matrix.case.conda }} pytest pytest-cov pytest-console-scripts coveralls flake8 setuptools-scm
+          python -m pip install ${{ matrix.case.pip }}
 
       - name: Conda list
         shell: bash -l {0}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ Changelog
 latest
 ------
 
+- New module ``inversion``:
+
+  - pyGIMLi(emg3d)
+
 Maintenance
 
   - Add notes for ``ipympl`` (interactive plots in modern Jupyter).

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -27,6 +27,7 @@ API reference
    surveys
    time
    utils
+   inversion/index
 
 
 .. grid:: 1

--- a/docs/api/inversion/index.rst
+++ b/docs/api/inversion/index.rst
@@ -1,0 +1,21 @@
+.. _inversionapi:
+
+Inversion
+#########
+
+.. automodapi:: emg3d.inversion
+   :no-inheritance-diagram:
+   :no-heading:
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   pygimli
+
+.. grid:: 1
+    :gutter: 2
+
+    .. grid-item-card::
+
+        pyGIMLi(emg3d): :mod:`emg3d.inversion.pygimli`

--- a/docs/api/inversion/pygimli.rst
+++ b/docs/api/inversion/pygimli.rst
@@ -1,0 +1,6 @@
+pyGIMLi(emg3d)
+==============
+
+.. automodapi:: emg3d.inversion.pygimli
+   :no-inheritance-diagram:
+   :no-heading:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ intersphinx_mapping = {
     "empymod": ("https://empymod.emsig.xyz/en/stable", None),
     "xarray": ("https://docs.xarray.dev/en/stable", None),
     "numba": ("https://numba.readthedocs.io/en/stable", None),
+    "pygimli": ("https://www.pygimli.org", None),
 }
 
 # ==== 2. General Settings ====

--- a/docs/manual/installation.rst
+++ b/docs/manual/installation.rst
@@ -40,6 +40,9 @@ or via ``pip``:
 
    pip install emg3d[full]
 
+The wrappers provided in :mod:`emg3d.inversion` may require additional
+packages, please consult the :ref:`inversionapi`-API for more information.
+
 If you are new to Python we recommend using a Python distribution, which will
 ensure that all dependencies are met, specifically properly compiled versions
 of ``NumPy`` and ``SciPy``; we recommend using `Anaconda

--- a/emg3d/__init__.py
+++ b/emg3d/__init__.py
@@ -22,6 +22,7 @@ from emg3d.electrodes import (
     RxElectricPoint, RxMagneticPoint,
 )
 from emg3d.fields import Field, get_source_field, get_magnetic_field
+from emg3d import inversion
 from emg3d.io import save, load, convert
 from emg3d.meshes import TensorMesh, construct_mesh
 from emg3d.models import Model

--- a/emg3d/_multiprocessing.py
+++ b/emg3d/_multiprocessing.py
@@ -43,6 +43,7 @@ def process_map(fn, *iterables, max_workers, **kwargs):
     execution.
 
     """
+    process_map.count += 1
 
     # Parallel
     if max_workers > 1 and tqdm is None:
@@ -62,6 +63,10 @@ def process_map(fn, *iterables, max_workers, **kwargs):
     else:
         return list(tqdm.auto.tqdm(
             iterable=map(fn, *iterables), total=len(iterables[0]), **kwargs))
+
+
+# Counter for processing map (used, e.g., for inversions).
+process_map.count = 0
 
 
 def solve(inp):

--- a/emg3d/inversion/__init__.py
+++ b/emg3d/inversion/__init__.py
@@ -1,0 +1,43 @@
+"""
+The inversion submodule of emg3d provides wrapper functionalities to use emg3d
+as a forward modelling kernel within third-party inversion frameworks. These
+third-party libraries are not included in emg3d, you have to install them
+Separately.
+
+Currently implemented wrappers and their corresponding requirements:
+
+- pyGIMLi(emg3d): Requires the *Geophysical Inversion & Modelling
+  Library* `pyGIMLi <https://pygimli.org>`_.
+"""
+# Copyright 2024 The emsig community.
+#
+# This file is part of emg3d.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+import importlib as _importlib
+
+
+submodules = [
+    'pygimli',
+]
+
+__all__ = submodules
+
+
+def __dir__():
+    return __all__
+
+
+def __getattr__(name):
+    if name in submodules:
+        return _importlib.import_module(f"emg3d.inversion.{name}")

--- a/emg3d/inversion/pygimli.py
+++ b/emg3d/inversion/pygimli.py
@@ -1,0 +1,342 @@
+"""
+Thin wrappers to use emg3d as a forward modelling kernel within the
+*Geophysical Inversion & Modelling Library* `pyGIMLi <https://pygimli.org>`_.
+
+It deals mainly with converting the data and model from the emg3d format to the
+pyGIMLi format and back, and creating the correct classes and functions as
+expected by a pyGIMLi inversion.
+"""
+# Copyright 2024 The emsig community.
+#
+# This file is part of emg3d.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+import numpy as np
+
+from emg3d import utils, _multiprocessing
+
+try:
+    import pygimli
+    # Add pygimli and pgcore to the emg3d.Report().
+    utils.OPTIONAL.extend(['pygimli', 'pgcore'])
+except ImportError:
+    pygimli = None
+
+__all__ = ['Kernel', 'Inversion']
+
+
+def __dir__():
+    return __all__
+
+
+class Kernel(pygimli.Modelling if pygimli else object):
+    """Create a forward operator of emg3d to use within a pyGIMLi inversion.
+
+
+    Parameters
+    ----------
+    simulation : Simulation
+        The simulation; a :class:`emg3d.simulations.Simulation` instance.
+
+    markers : ndarray of dtype int, default: None
+        An ndarray of integers of the same shape as the model. All cells with
+        the same number belong to the same region with this number, which can
+        subsequently be defined through
+        :func:`pygimli.frameworks.modelling.Modelling.setRegionProperties`.
+
+    pgthreads : int, default: 2
+        Number of threads for pyGIMLi (sets ``OPENBLAS_NUM_THREADS``). This is
+        by default a small number, as the important parallelization in
+        pyGIMLi(emg3d) happens over sources and frequencies in emg3d. This is
+        controlled in the parameter ``max_workers`` when creating the
+        simulation.
+
+    """
+
+    @utils._requires('pygimli')
+    def __init__(self, simulation, markers=None, pgthreads=2):
+        """Initialize a pyGIMLi(emg3d)-wrapper."""
+        super().__init__()
+
+        # Set pyGIMLi threads.
+        pygimli.setThreadCount(pgthreads)
+
+        # Check current limitations.
+        checks = {
+            'case': (simulation.model.case, 'isotropic'),
+            'mapping': (simulation.model.map.name, 'Conductivity'),
+        }
+        for k, v in checks.items():
+            if v[0] != v[1]:
+                msg = f"pyGIMLi(emg3d) is not implemented for {v[0]} {k}."
+                raise NotImplementedError(msg)
+
+        # Store the simulation.
+        self.simulation = simulation
+
+        # Translate discretize TensorMesh to pygimli-Grid.
+        mesh = pygimli.createGrid(
+            x=simulation.model.grid.nodes_x,
+            y=simulation.model.grid.nodes_y,
+            z=simulation.model.grid.nodes_z,
+        )
+
+        # Set markers.
+        if markers is not None:
+            self.markers = markers
+        else:
+            self.markers = np.arange(simulation.model.size, dtype=int)
+        mesh.setCellMarkers(self.markers.ravel('F'))
+        # Store original props; required if a region is set to ``background``.
+        self._model = simulation.model.property_x.copy()
+        # Store volumes; required if a region is set to ``single``.
+        self._volumes = simulation.model.grid.cell_volumes.reshape(
+                self._model.shape, order='F')
+        # Set mesh.
+        self.setMesh(mesh)
+        self._fullmodel = None
+
+        # Create J, store and set it.
+        self.J = self.Jacobian(
+            simulation=self.simulation,
+            data2gimli=self.data2gimli,
+            data2emg3d=self.data2emg3d,
+            model2gimli=self.model2gimli,
+            model2emg3d=self.model2emg3d,
+        )
+        self.setJacobian(self.J)
+
+    def response(self, model):
+        """Create synthetic data for provided pyGIMLi model."""
+
+        # Clean emg3d-simulation, so things are recomputed
+        self.simulation.clean('computed')
+
+        # Replace model
+        self.simulation.model.property_x = self.model2emg3d(model)
+
+        # Compute forward model and set initial residuals.
+        _ = self.simulation.misfit
+
+        # Return the responses as pyGIMLi array
+        return self.data2gimli(self.simulation.data.synthetic.data)
+
+    def createStartModel(self, dataVals=None):
+        """Returns the model from the provided simulation."""
+        return self.model2gimli(self.simulation.model.property_x)
+
+    def createJacobian(self, model):
+        """Dummy to prevent pyGIMLi from doing it the hard way."""
+
+    def data2gimli(self, data):
+        """Convert an emg3d data-xarray to a pyGIMLi data array."""
+        out = data[self.simulation.survey.isfinite]
+        if np.iscomplexobj(out):
+            return np.hstack((out.real, out.imag))
+        else:  # For standard deviation
+            return np.hstack((out, out))
+
+    def data2emg3d(self, data):
+        """Convert a pyGIMLi data array to an emg3d data-xarray."""
+        out = np.ones(
+                self.simulation.survey.shape,
+                dtype=self.simulation.data.observed.dtype
+        )*np.nan
+        data = np.asarray(data)
+        ind = data.size//2
+        out[self.simulation.survey.isfinite] = data[:ind] + 1j*data[ind:]
+        return out
+
+    def model2gimli(self, model):
+        """Convert an emg3d Model property to a pyGIMLi model array.
+
+        This function deals with the regions defined in pyGIMLi.
+        """
+
+        # If the inversion model is smaller than the model, we have to
+        # take care of the regions.
+        if self.fullmodel:
+
+            out = np.empty(model.size)
+            out[self.mesh().cellMarkers()] = model.ravel('F')
+
+        else:
+
+            out = np.empty(self.simulation.model.size)
+            i = 0
+
+            for n, v in self.regionProperties().items():
+                ni = self.markers == n
+                if v['background'] or v['fix']:
+                    ii = 0
+                elif v['single']:
+                    ii = 1
+                    out[i] = np.average(model[ni], weights=self._volumes[ni])
+                else:
+                    ii = np.sum(ni)
+                    out[i:i+ii] = model[ni]
+                i += ii
+
+            out = out[:i]
+
+        return out
+
+    def model2emg3d(self, model):
+        """Convert a pyGIMLi model array to an emg3d Model property.
+
+        This function deals with the regions defined in pyGIMLi.
+        """
+
+        # If the inversion model is smaller than the model, we have to
+        # take care of the regions.
+        if self.fullmodel:
+
+            out = np.asarray(model[self.mesh().cellMarkers()]).reshape(
+                    self.simulation.model.shape, order='F')
+
+        else:
+
+            out = np.empty(self.simulation.model.shape)
+            i = 0
+
+            for n, v in self.regionProperties().items():
+                ni = self.markers == n
+                if v['background']:
+                    ii = 0
+                    out[ni] = self._model[ni]
+                elif v['fix']:
+                    ii = 0
+                    out[ni] = v['startModel']
+                elif v['single']:
+                    ii = 1
+                    out[ni] = model[i]
+                else:
+                    ii = np.sum(ni)
+                    out[ni] = model[i:ii+i]
+                i += ii
+
+        return out
+
+    @property
+    def fullmodel(self):
+        """Flag if the full model is used for the inversion or not."""
+        if self._fullmodel is None:
+            self._fullmodel = True
+            if self.regionProperties():
+                keys = ['background', 'fix', 'single']
+                for v in self.regionProperties().values():
+                    if np.any([v[k] is True for k in keys]):
+                        self._fullmodel = False
+                        break
+
+        return self._fullmodel
+
+    class Jacobian(pygimli.Matrix if pygimli else object):
+        """Return Jacobian operator for pyGIMLi(emg3d)."""
+
+        def __init__(self, simulation,
+                     data2gimli, data2emg3d, model2gimli, model2emg3d):
+            """Initiate a new Jacobian instance."""
+            super().__init__()
+            self.simulation = simulation
+            self.data2gimli = data2gimli
+            self.data2emg3d = data2emg3d
+            self.model2gimli = model2gimli
+            self.model2emg3d = model2emg3d
+
+        def cols(self):
+            """The number of columns corresponds to the model size."""
+            return self.simulation.model.size
+
+        def rows(self):
+            """The number of rows corresponds to 2x data-size (Re; Im)."""
+            return self.simulation.survey.count * 2
+
+        def mult(self, x):
+            """Multiply the Jacobian with a vector, Jm."""
+            jvec = self.simulation.jvec(vector=self.model2emg3d(x))
+            return self.data2gimli(jvec)
+
+        def transMult(self, x):
+            """Multiply  Jacobian transposed with a vector, Jᵀd = (dJᵀ)ᵀ."""
+            jtvec = self.simulation.jtvec(self.data2emg3d(x))
+            return self.model2gimli(jtvec)
+
+        def save(self, *args):
+            """There is no save for this pseudo-Jacobian."""
+
+
+@utils._requires('pygimli')
+class Inversion(pygimli.Inversion if pygimli else object):
+    """Thin wrapper, adding verbosity and taking care of data format."""
+
+    @utils._requires('pygimli')
+    def __init__(self, fop=None, inv=None, **kwargs):
+        """Initialize an Inversion instance."""
+        super().__init__(fop=fop, inv=inv, **kwargs)
+        self._postStep = _post_step
+
+    def run(self, dataVals=None, errorVals=None, **kwargs):
+        """Run the inversion."""
+
+        # Reset counter, start timer, print message.
+        _multiprocessing.process_map.count = 0
+        timer = utils.Timer()
+        pygimli.info(":: pyGIMLi(emg3d) START ::")
+
+        # Take data from the survey if not provided.
+        if dataVals is None:
+            dataVals = self.fop.data2gimli(
+                    self.fop.simulation.data.observed.data)
+
+        # Take the error from the survey if not provided.
+        if errorVals is None:
+            std_dev = self.fop.data2gimli(
+                    self.fop.simulation.survey.standard_deviation.data)
+            errorVals = std_dev / abs(dataVals)
+
+        # Reset full-model flag.
+        self.fop._fullmodel = None
+
+        # Run the inversion
+        out = super().run(dataVals=dataVals, errorVals=errorVals, **kwargs)
+
+        # Print passed time and exit
+        pygimli.info(f":: pyGIMLi(emg3d) END   :: runtime = {timer.runtime}")
+
+        return out
+
+
+def _post_step(n, inv):
+    """Print some values for each iteration."""
+
+    # Print info
+    sim = inv.fop.simulation
+    sim.survey.data[f"it{n}"] = sim.survey.data.synthetic
+    phi = inv.inv.getPhi()
+    if not hasattr(inv, 'lastphi'):
+        lastphi = ""
+    else:
+        lastphi = f"; Δϕ = {(1-phi/inv.lastphi)*100:.2f}%"
+    inv.lastphi = phi
+    pygimli.info(
+        f"{n}: "
+        f"χ² = {inv.inv.chi2():7.2f}; "
+        f"λ = {inv.inv.getLambda()}; "
+        f"{_multiprocessing.process_map.count:2d} kernel calls; "
+        f"ϕ = {inv.inv.getPhiD():.2f} + {inv.inv.getPhiM():.2f}·λ = "
+        f"{phi:.2f}{lastphi}"
+    )
+
+    # Reset counter
+    _multiprocessing.process_map.count = 0

--- a/emg3d/inversion/pygimli.py
+++ b/emg3d/inversion/pygimli.py
@@ -71,11 +71,15 @@ class Kernel(pygimli.Modelling if pygimli else object):
         # Set pyGIMLi threads.
         pygimli.setThreadCount(pgthreads)
 
-        # Check isotropic limitation.
-        iso = simulation.model.case
-        if iso != 'isotropic':
-            msg = f"pyGIMLi(emg3d) is not implemented for {iso} case."
-            raise NotImplementedError(msg)
+        # Check current limitations.
+        checks = {
+            'case': (simulation.model.case, 'isotropic'),
+            'mapping': (simulation.model.map.name, 'Conductivity'),
+        }
+        for k, v in checks.items():
+            if v[0] != v[1]:
+                msg = f"pyGIMLi(emg3d) is not implemented for {v[0]} {k}."
+                raise NotImplementedError(msg)
 
         # Store the simulation.
         self.simulation = simulation
@@ -174,6 +178,7 @@ class Kernel(pygimli.Modelling if pygimli else object):
                     ii = 0
                 elif v['single']:
                     ii = 1
+                    # TODO: Should av. happen on log-scale (not for jtvec)
                     out[i] = np.average(model[ni], weights=self._volumes[ni])
                 else:
                     ii = np.sum(ni)
@@ -217,8 +222,9 @@ class Kernel(pygimli.Modelling if pygimli else object):
                 elif v['single']:
                     ii = 1
                     out[ni] = model[i]
-                    if jvec:  # TODO:: Necessary to normalize?
-                        out[ni] *= self._volumes[ni]/self._volumes[ni].sum()
+                    # TODO:: Necessary to normalize?
+                    # if jvec:
+                    #     out[ni] *= self._volumes[ni]/self._volumes[ni].sum()
                 else:
                     ii = np.sum(ni)
                     out[ni] = model[i:ii+i]

--- a/emg3d/inversion/pygimli.py
+++ b/emg3d/inversion/pygimli.py
@@ -173,7 +173,8 @@ class Kernel(pygimli.Modelling if pygimli else object):
             i = 0
 
             for n, v in self.regionProperties().items():
-                ni = self.markers == n
+                nn = self.markers == n
+                ni = nn[np.asarray(self.mesh().cellMarkers())]
                 if v['background'] or v['fix']:
                     ii = 0
                 elif v['single']:
@@ -206,7 +207,8 @@ class Kernel(pygimli.Modelling if pygimli else object):
             i = 0
 
             for n, v in self.regionProperties().items():
-                ni = self.markers == n
+                nn = self.markers == n
+                ni = nn[np.asarray(self.mesh().cellMarkers())]
                 if v['background']:
                     ii = 0
                     out[ni] = self._model.property_x.ravel('F')[ni]

--- a/emg3d/inversion/pygimli.py
+++ b/emg3d/inversion/pygimli.py
@@ -71,15 +71,10 @@ class Kernel(pygimli.Modelling if pygimli else object):
         # Set pyGIMLi threads.
         pygimli.setThreadCount(pgthreads)
 
-        # Check current limitations.
-        checks = {
-            'case': (simulation.model.case, 'isotropic'),
-            'mapping': (simulation.model.map.name, 'Conductivity'),
-        }
-        for k, v in checks.items():
-            if v[0] != v[1]:
-                msg = f"pyGIMLi(emg3d) is not implemented for {v[0]} {k}."
-                raise NotImplementedError(msg)
+        # Check isotropic limitation.
+        if iso := simulation.model.case != 'isotropic':
+            msg = f"pyGIMLi(emg3d) is not implemented for {iso} case."
+            raise NotImplementedError(msg)
 
         # Store the simulation.
         self.simulation = simulation

--- a/emg3d/inversion/pygimli.py
+++ b/emg3d/inversion/pygimli.py
@@ -261,11 +261,16 @@ class Kernel(pygimli.Modelling if pygimli else object):
 
         def cols(self):
             """The number of columns corresponds to the model size."""
-            return self.simulation.model.size
+            if not hasattr(self, '_cols'):
+                gmodel = self.model2gimli(self.simulation.model.property_x)
+                self._cols = len(gmodel)
+            return self._cols
 
         def rows(self):
             """The number of rows corresponds to 2x data-size (Re; Im)."""
-            return self.simulation.survey.count * 2
+            if not hasattr(self, '_rows'):
+                self._rows = self.simulation.survey.count * 2
+            return self._rows
 
         def mult(self, x):
             """Multiply the Jacobian with a vector, Jm."""
@@ -281,7 +286,6 @@ class Kernel(pygimli.Modelling if pygimli else object):
             """There is no save for this pseudo-Jacobian."""
 
 
-@utils._requires('pygimli')
 class Inversion(pygimli.Inversion if pygimli else object):
     """Thin wrapper, adding verbosity and taking care of data format."""
 

--- a/emg3d/inversion/pygimli.py
+++ b/emg3d/inversion/pygimli.py
@@ -172,9 +172,8 @@ class Kernel(pygimli.Modelling if pygimli else object):
         else:
             i = 0
 
-            for n, v in self.regionProperties().items():
-                nn = self.markers == n
-                ni = nn[np.asarray(self.mesh().cellMarkers())]
+            for n, v in sorted(self.regionProperties().items()):
+                ni = self.markers == n
                 if v['background'] or v['fix']:
                     ii = 0
                 elif v['single']:
@@ -206,9 +205,8 @@ class Kernel(pygimli.Modelling if pygimli else object):
             out = np.empty(self.simulation.model.size)
             i = 0
 
-            for n, v in self.regionProperties().items():
-                nn = self.markers == n
-                ni = nn[np.asarray(self.mesh().cellMarkers())]
+            for n, v in sorted(self.regionProperties().items()):
+                ni = self.markers == n
                 if v['background']:
                     ii = 0
                     out[ni] = self._model.property_x.ravel('F')[ni]

--- a/emg3d/inversion/pygimli.py
+++ b/emg3d/inversion/pygimli.py
@@ -354,10 +354,10 @@ def _post_step(n, inv):
         deltaphi = (1-phi/inv.lastphi)*100
     inv.lastphi = phi
     pygimli.info(
-        f"{n:3d}{np.round(inv.inv.chi2(), 1):10.6g}"
-        f"{_multiprocessing.process_map.count:7d}{inv.inv.getLambda():8.3g}"
-        f"{np.round(inv.inv.getPhiD(), 1):10.6g}"
-        f"{np.round(inv.inv.getPhiM(), 1):10.6g}{np.round(phi, 1):12.6g}"
+        f"{n:3d}{np.round(inv.inv.chi2(), 1):10.6}"
+        f"{_multiprocessing.process_map.count:7d}{inv.inv.getLambda():8.3}"
+        f"{np.round(inv.inv.getPhiD(), 1):10.6}"
+        f"{np.round(inv.inv.getPhiM(), 1):10.6}{np.round(phi, 1):12.6}"
         f"{deltaphi:9.2f}"
     )
 

--- a/emg3d/inversion/pygimli.py
+++ b/emg3d/inversion/pygimli.py
@@ -203,10 +203,11 @@ class Kernel(pygimli.Modelling if pygimli else object):
 
         else:
 
+            # TODO: default for jvec: zeros, ones, something else?
             out = np.zeros(self.simulation.model.size)
             i = 0
 
-            # TODO:: If `jvec` and `mapping != 'Conductivity'`: chain rule?
+            # TODO:: What about dsigma dm?
 
             for n, v in sorted(self.regionProperties().items()):
                 ni = self.markers == n
@@ -319,12 +320,18 @@ class Inversion(pygimli.Inversion if pygimli else object):
 
         # Run the inversion
         out = super().run(dataVals=dataVals, errorVals=errorVals, **kwargs)
+
+        # Store last model in the simulation
         self.fop.simulation.model.property_x = self.fop.model2emg3d(out)
+
+        # Store last iteration as inversion result
+        survey = self.fop.simulation.survey
+        n = self.inv.iter()
+        survey.data["inv"] = self.fop.simulation.data[f"it{n}"].copy()
+        survey.data["inv"].data[np.invert(survey.isfinite)] *= np.nan
 
         # Print passed time and exit
         pygimli.info(f":: pyGIMLi(emg3d) END   :: runtime = {timer.runtime}")
-
-        return self.fop.simulation.model
 
 
 def _post_step(n, inv):

--- a/emg3d/inversion/pygimli.py
+++ b/emg3d/inversion/pygimli.py
@@ -72,7 +72,8 @@ class Kernel(pygimli.Modelling if pygimli else object):
         pygimli.setThreadCount(pgthreads)
 
         # Check isotropic limitation.
-        if iso := simulation.model.case != 'isotropic':
+        iso = simulation.model.case
+        if iso != 'isotropic':
             msg = f"pyGIMLi(emg3d) is not implemented for {iso} case."
             raise NotImplementedError(msg)
 

--- a/emg3d/inversion/pygimli.py
+++ b/emg3d/inversion/pygimli.py
@@ -343,9 +343,9 @@ def _post_step(n, inv):
     phi = inv.inv.getPhi()
     if n == 0:
         pygimli.info(
-            f"{70*'='}\n{39*' '}"
-            " it        χ²   F(m)       λ        ϕᵈ        ϕᵐ"
-            f"    ϕ=ϕᵈ+λϕᵐ   Δϕ (%)\n{39*' '}{70*'-'}"
+            f"{71*'='}\n{39*' '}"
+            " it        χ²   F(m)       λ         ϕᵈ         ϕᵐ"
+            f"   ϕ=ϕᵈ+λϕᵐ   Δϕ (%)\n{39*' '}{71*'-'}"
         )
         deltaphi = 0
         sim.invinfo = {}
@@ -354,10 +354,10 @@ def _post_step(n, inv):
         deltaphi = (1-phi/inv.lastphi)*100
     inv.lastphi = phi
     pygimli.info(
-        f"{n:3d}{np.round(inv.inv.chi2(), 1):10.6}"
+        f"{n:3d}{_round_format(inv.inv.chi2())}"
         f"{_multiprocessing.process_map.count:7d}{inv.inv.getLambda():8.3}"
-        f"{np.round(inv.inv.getPhiD(), 1):10.6}"
-        f"{np.round(inv.inv.getPhiM(), 1):10.6}{np.round(phi, 1):12.6}"
+        f" {_round_format(inv.inv.getPhiD())}"
+        f" {_round_format(inv.inv.getPhiM())} {_round_format(phi)}"
         f"{deltaphi:9.2f}"
     )
 
@@ -387,3 +387,8 @@ def _post_step(n, inv):
 
     # Reset counter
     _multiprocessing.process_map.count = 0
+
+
+def _round_format(x, ndigit=1, threshold=1e6, lower='10.1f', upper='10.3'):
+    """Rounding numbers for info display."""
+    return f"{np.round(x, ndigit):{lower if x < threshold else upper}}"

--- a/emg3d/simulations.py
+++ b/emg3d/simulations.py
@@ -301,7 +301,7 @@ class Simulation:
 
         # Initiate synthetic data with NaN's if they don't exist.
         if 'synthetic' not in self.survey.data.keys():
-            self.survey._data['synthetic'] = self.data.observed.copy(
+            self.survey.data['synthetic'] = self.data.observed.copy(
                     data=np.full(self.survey.shape, np.nan+1j*np.nan))
 
         # `tqdm`-options.

--- a/emg3d/utils.py
+++ b/emg3d/utils.py
@@ -42,6 +42,8 @@ except ImportError:
 
 __all__ = ['Report', 'EMArray', 'Timer']
 
+OPTIONAL = ['xarray', 'discretize', 'h5py', 'matplotlib', 'tqdm', 'IPython']
+
 
 def __dir__():
     return __all__
@@ -158,8 +160,7 @@ class Report(ScoobyReport):
         core = ['numpy', 'scipy', 'numba', 'emg3d', 'empymod']
 
         # Optional packages.
-        optional = ['xarray', 'discretize', 'h5py', 'matplotlib',
-                    'tqdm', 'IPython']
+        optional = OPTIONAL
 
         super().__init__(additional=add_pckg, core=core, optional=optional,
                          ncol=ncol, text_width=text_width, sort=sort)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,7 @@ xarray
 discretize
 matplotlib
 ipympl
+pygimli
 
 # SETUP RELATED
 setuptools_scm

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author_email="info@emsig.xyz",
     url="https://emsig.xyz",
     license="Apache-2.0",
-    packages=["emg3d", "emg3d.cli"],
+    packages=["emg3d", "emg3d.inversion", "emg3d.cli"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: Apache Software License",

--- a/tests/test_pygimli.py
+++ b/tests/test_pygimli.py
@@ -158,7 +158,7 @@ class TestPygimli():
 
         assert 'pyGIMLi(emg3d)' in caplog.text
         assert 'Created startmodel from forward operator: 27' in caplog.text
-        assert 'λ = 0.1' in caplog.text
+        assert '1     0.1' in caplog.text
 
         assert INV.inv.chi2() < 1
 
@@ -185,8 +185,7 @@ class TestPygimli():
 
         assert 'pyGIMLi(emg3d)' in caplog.text
         assert 'Created startmodel from region infos: 2' in caplog.text
-        assert 'λ = 1.0' in caplog.text
-
+        assert '1       1' in caplog.text
         assert INV.inv.chi2() < 1
 
 

--- a/tests/test_pygimli.py
+++ b/tests/test_pygimli.py
@@ -154,7 +154,7 @@ class TestPygimli():
         INV.inv.setCGLSTolerance(10)
         INV.inv.setMaxCGLSIter(30)
 
-        _ = INV.run(maxIter=2, lam=0.1)
+        INV.run(maxIter=2, lam=0.1)
 
         assert 'pyGIMLi(emg3d)' in caplog.text
         assert 'Created startmodel from forward operator: 27' in caplog.text
@@ -181,7 +181,7 @@ class TestPygimli():
         INV.fop.setRegionProperties(
                 3, single=True, limits=(0.99999, 1.00001), startModel=1.0)
 
-        _ = INV.run(maxIter=2, lam=1)
+        INV.run(maxIter=2, lam=1)
 
         assert 'pyGIMLi(emg3d)' in caplog.text
         assert 'Created startmodel from region infos: 2' in caplog.text

--- a/tests/test_pygimli.py
+++ b/tests/test_pygimli.py
@@ -83,6 +83,10 @@ class TestPygimli():
     def test_Kernel_errors(self):
 
         sim = self.sim.copy()
+        sim.model = emg3d.Model(sim.model.grid, mapping='Resistivity')
+        with pytest.raises(NotImplementedError, match='for Resistivity'):
+            _ = ipygimli.Kernel(simulation=sim)
+
         sim.model = emg3d.Model(sim.model.grid, 1, 2)
         with pytest.raises(NotImplementedError, match='for HTI'):
             _ = ipygimli.Kernel(simulation=sim)

--- a/tests/test_pygimli.py
+++ b/tests/test_pygimli.py
@@ -83,10 +83,6 @@ class TestPygimli():
     def test_Kernel_errors(self):
 
         sim = self.sim.copy()
-        sim.model = emg3d.Model(sim.model.grid, mapping='Resistivity')
-        with pytest.raises(NotImplementedError, match='for Resistivity'):
-            _ = ipygimli.Kernel(simulation=sim)
-
         sim.model = emg3d.Model(sim.model.grid, 1, 2)
         with pytest.raises(NotImplementedError, match='for HTI'):
             _ = ipygimli.Kernel(simulation=sim)

--- a/tests/test_pygimli.py
+++ b/tests/test_pygimli.py
@@ -1,0 +1,195 @@
+import pytest
+import logging
+import numpy as np
+from numpy.testing import assert_allclose
+
+import emg3d
+from emg3d import inversion
+from emg3d.inversion import pygimli as ipygimli
+
+
+# Soft dependencies
+try:
+    import xarray
+except ImportError:
+    xarray = None
+try:
+    import discretize
+except ImportError:
+    discretize = None
+try:
+    import pygimli
+except ImportError:
+    pygimli = None
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+@pytest.mark.skipif(xarray is None, reason="xarray not installed.")
+class TestPygimli():
+
+    if xarray is not None:
+        # Create data
+        survey = emg3d.surveys.Survey(
+            sources=emg3d.TxElectricDipole((0, 0, -250, 0, 0)),
+            receivers=emg3d.RxElectricPoint((0, 0, -1250, 0, 0)),
+            frequencies=1.0,
+            noise_floor=1e-17,
+            relative_error=0.05,
+        )
+
+        hx = np.ones(3)*500.0
+        grid = emg3d.TensorMesh([hx, hx, hx], [-750, -750, -1500])
+
+        model_start = emg3d.Model(grid, 1.0, mapping='Conductivity')
+        model_true = emg3d.Model(grid, 1.0, mapping='Conductivity')
+        model_true.property_x[1, 1, 1] = 1/1000
+
+        # Create an emg3d Simulation instance
+        sim = emg3d.simulations.Simulation(
+            survey=survey.copy(),
+            model=model_true,
+            gridding='both',
+            max_workers=1,
+            gridding_opts={'center_on_edge': False},
+            receiver_interpolation='linear',
+            solver_opts={'tol_gradient': 1e-2},
+            tqdm_opts=False,
+        )
+        sim.compute(observed=True)
+        synthetic = sim.survey.data.synthetic.copy()
+        sim.clean('computed')
+
+        sim.model = model_start
+
+        sim.compute()
+        sim.survey.data['start'] = sim.survey.data.synthetic
+        sim.clean('computed')
+
+        markers = np.zeros(sim.model.shape, dtype=int)
+        markers[1, 1, 1] = 1
+        markers[0, :, :] = 2
+        markers[2, :, :] = 3
+
+        def set_regions(self, fop):
+            fop.setRegionProperties(1, limits=(0.0001, 2), startModel=1.0)
+            fop.setRegionProperties(0, background=True)
+            fop.setRegionProperties(2, fix=True, startModel=1)
+            fop.setRegionProperties(
+                    3, single=True, limits=(0.99999, 1.00001), startModel=1.0)
+
+    @pytest.mark.skipif(pygimli is None, reason="pygimli not installed.")
+    def test_Kernel_errors(self):
+
+        sim = self.sim.copy()
+        sim.model = emg3d.Model(sim.model.grid, mapping='Resistivity')
+        with pytest.raises(NotImplementedError, match='for Resistivity'):
+            _ = ipygimli.Kernel(simulation=sim)
+
+        sim.model = emg3d.Model(sim.model.grid, 1, 2)
+        with pytest.raises(NotImplementedError, match='for HTI'):
+            _ = ipygimli.Kernel(simulation=sim)
+
+    @pytest.mark.skipif(pygimli is None, reason="pygimli not installed.")
+    def test_Kernel_markers(self):
+
+        # No regions
+        sim = self.sim.copy()
+        fop = ipygimli.Kernel(simulation=sim)
+        assert_allclose(fop.markers, np.arange(sim.model.size, dtype=int))
+        assert fop.fullmodel is True
+
+        # Regions
+        fop = ipygimli.Kernel(simulation=sim, markers=self.markers)
+        self.set_regions(fop)
+        assert_allclose(fop.markers, self.markers)
+        assert fop.fullmodel is False
+
+    @pytest.mark.skipif(pygimli is None, reason="pygimli not installed.")
+    def test_Kernel_conversions(self):
+        sim = self.sim.copy()
+        fop1 = ipygimli.Kernel(simulation=sim)
+        fop2 = ipygimli.Kernel(simulation=sim, markers=self.markers)
+        self.set_regions(fop2)
+
+        for fop in [fop1, fop2]:
+
+            assert_allclose(
+                fop.model2emg3d(fop.createStartModel()),
+                sim.model.property_x
+            )
+
+            assert_allclose(
+                sim.data.observed,
+                fop.data2emg3d(fop.data2gimli(sim.data.observed.data))
+            )
+
+            assert_allclose(
+                sim.model.property_x,
+                fop.model2emg3d(fop.model2gimli(sim.model.property_x))
+            )
+            data = sim.survey.standard_deviation.data
+            assert fop.data2gimli(data).dtype == np.float64
+
+    @pytest.mark.skipif(pygimli is None, reason="pygimli not installed.")
+    def test_Kernel_response(self):
+        sim = self.sim.copy()
+        sim.model = self.model_true
+        fop = ipygimli.Kernel(simulation=sim)
+        assert_allclose(
+            fop.data2emg3d(fop.response(fop.createStartModel())),
+            self.synthetic.data
+        )
+
+    @pytest.mark.skipif(pygimli is None, reason="pygimli not installed.")
+    @pytest.mark.skipif(discretize is None, reason="discretize not installed.")
+    def test_Inversion_noregions(self, caplog):
+        # Mainly "runtest"
+        sim = self.sim.copy()
+
+        fop = ipygimli.Kernel(simulation=sim, pgthreads=1)
+
+        INV = ipygimli.Inversion(fop=fop)
+        INV.inv.setCGLSTolerance(10)
+        INV.inv.setMaxCGLSIter(30)
+
+        _ = INV.run(maxIter=2, lam=0.1)
+
+        assert 'pyGIMLi(emg3d)' in caplog.text
+        assert 'Created startmodel from forward operator: 27' in caplog.text
+        assert 'λ = 0.1' in caplog.text
+
+        assert INV.inv.chi2() < 1
+
+    @pytest.mark.skipif(pygimli is None, reason="pygimli not installed.")
+    @pytest.mark.skipif(discretize is None, reason="discretize not installed.")
+    def test_Inversion_regions(self, caplog):
+        # Mainly "runtest"
+        sim = self.sim.copy()
+
+        fop = ipygimli.Kernel(
+                simulation=sim, markers=self.markers, pgthreads=1)
+
+        INV = ipygimli.Inversion(fop=fop)
+        INV.inv.setCGLSTolerance(10)
+        INV.inv.setMaxCGLSIter(30)
+
+        INV.fop.setRegionProperties(1, limits=(0.0001, 2), startModel=1.0)
+        INV.fop.setRegionProperties(0, background=True)
+        INV.fop.setRegionProperties(2, fix=True, startModel=1)
+        INV.fop.setRegionProperties(
+                3, single=True, limits=(0.99999, 1.00001), startModel=1.0)
+
+        _ = INV.run(maxIter=2, lam=1)
+
+        assert 'pyGIMLi(emg3d)' in caplog.text
+        assert 'Created startmodel from region infos: 2' in caplog.text
+        assert 'λ = 1.0' in caplog.text
+
+        assert INV.inv.chi2() < 1
+
+
+def test_all_dir():
+    assert set(inversion.__all__) == set(dir(inversion))
+    assert set(ipygimli.__all__) == set(dir(ipygimli))

--- a/tests/test_pygimli.py
+++ b/tests/test_pygimli.py
@@ -103,7 +103,7 @@ class TestPygimli():
         # Regions
         fop = ipygimli.Kernel(simulation=sim, markers=self.markers)
         self.set_regions(fop)
-        assert_allclose(fop.markers, self.markers)
+        assert_allclose(fop.markers, self.markers.ravel('F'))
         assert fop.fullmodel is False
 
     @pytest.mark.skipif(pygimli is None, reason="pygimli not installed.")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_allclose
 
 import scooby
 from emg3d import utils
+from emg3d.inversion import pygimli as ipygimli
 
 
 def test_known_class():
@@ -30,13 +31,18 @@ def test_requires(capsys):
 def test_Report(capsys):
     out, _ = capsys.readouterr()  # Empty capsys
 
+    if ipygimli.pygimli is None:
+        add = []
+    else:
+        add = ['pygimli', 'pgcore']
+
     # Reporting is now done by the external package scooby.
     # We just ensure the shown packages do not change (core and optional).
     out1 = utils.Report()
     out2 = scooby.Report(
-            core=['numpy', 'scipy', 'numba', 'emg3d'],
+            core=['numpy', 'scipy', 'numba', 'emg3d', 'empymod'],
             optional=['empymod', 'xarray', 'discretize', 'h5py',
-                      'matplotlib', 'tqdm', 'IPython'],
+                      'matplotlib', 'tqdm', 'IPython'] + add,
             ncol=4)
 
     # Ensure they're the same; exclude time to avoid errors.


### PR DESCRIPTION
# pyGIMLi(emg3d)

Implementing an `emg3d.inversion` submodule with a first member `pygimli`, providing the two classes `emg3d.inversion.pygimli.Kernel` and `emg3d.inversion.pygimli.Inversion` to run an inversion using the pyGIMLi framework and emg3d as a forward modelling kernel.

## TODO:
- `mult/jvec`:
  - [ ]  For anything else than `mapping='Conductivity'`, we have to take care of the corresponding chain rule!
  - [ ] How to treat `background/fix`?
  - [ ] Do we have to scale for `single`? 
- [ ] Add example

### NOTE
With massive help from @halbmy and lots of testing from @mariacarrizo !