### PR TITLE
Merge once discretize for numpy>=2 is released

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ full = [
 ]
 docs = [
     "emg3d[full]",
-    "numpy<2",  # Until discretize is ready for NumPy v2
     "sphinx",
     "numpydoc",
     "ipykernel",


### PR DESCRIPTION
The `[docs]` in `pyproject.toml` limits currently `numpy<2`, to work with discretize through pip. This PR removes this limitation again.