### PR TITLE
Add a test for normalizing warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,20 @@ Changelog
 """"""""""
 
 
+v1.8.6 : Tmp restrict SciPy
+---------------------------
+
+**2025-01-07**
+
+- Maintenance:
+
+  - Restricting to ``SciPy<1.15``. The function ``scipy.interpolate.interpnd``
+    is deprecated, and ``scipy.interpolate.interpnd._ndim_coords_from_array``
+    was removed. Needs fixing in ``emg3d.maps._points_from_grids``.
+  - Re-adding a test for normalizing source warning; avoid rounding over and
+    over again in recursion of creating a dipole/wire source.
+
+
 v1.8.5 : Bugfix and pyproject
 -----------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 dependencies = [
     "numpy",
-    "scipy>=1.10",
+    "scipy (>=1.10,<1.15)",
     "numba",
     "empymod>=2.3.2",
 ]

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -715,6 +715,15 @@ class TestDipoleVector:
         with pytest.raises(ValueError, match='Provided finite dipole'):
             fields._dipole_vector(grid, source)
 
+        # Create a BaseMesh and modify the widths, so _dipole_vector will
+        # have to normalize.
+        h = np.ones(4)
+        grid = emg3d.meshes.BaseMesh([h, h, h], (0, 0, 0))
+        grid.h = [grid.h[0], grid.h[1]*.3, grid.h[2]]
+        source = np.array([[0, 1, 2], [3, 3, 2]])
+        with pytest.warns(UserWarning, match='Normalizing Source'):
+            fields._dipole_vector(grid, source)
+
 
 @pytest.mark.parametrize("njit", [True, False])
 def test_edge_curl_factor(njit):


### PR DESCRIPTION
`fields._dipole_vector`
- Add test for normalizing source warning
- Avoid rounding over and over again in recursion

Restricting to `SciPy<1.15`. The function `scipy.interpolate.interpnd` is deprecated, the following part has to be rewritten: https://github.com/emsig/emg3d/blob/main/emg3d/maps.py#L482-L485
